### PR TITLE
Added build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /java/test/nbproject/*
 
 /csharp/*
+.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,4 @@ task mvn_install_tweenengine(dependsOn: package_tweenengine){
 	}
 }
 
-mvn_install_tweenengine.mvn_dir = file('../apache-maven-3.3.9/bin')
-
 defaultTasks 'mvn_install_tweenengine'

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,29 @@
+ant.importBuild('java/build.xml') { 
+	antTargetName -> antTargetName + '_tweenengine'
+}
+
+task mvn_install_tweenengine(dependsOn: package_tweenengine){
+	ext.mvn_dir = projectDir //Default setting assumes that maven is added to your path
+	
+	doLast {
+		exec{
+			def api_dir = ant.properties['api.dir']
+			def api_name = ant.properties['api.name']
+			
+			def version = ant.properties['version']
+			
+			def cmdline = 'install:install-file -Dfile=' + projectDir + '/java/build/' + api_dir + '/' + api_name + '.jar -DgroupId=com.aurelienribon -DartifactId=tween-engine-api -Dversion=' + version + ' -Dpackaging=jar'
+		
+			workingDir = mvn_dir
+			if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
+				commandLine 'cmd', '/c', 'mvn.cmd ' + cmdline
+			} else {
+				commandLine 'mvn ' + cmdline
+			} 
+		}
+	}
+}
+
+mvn_install_tweenengine.mvn_dir = file('../apache-maven-3.3.9/bin')
+
+defaultTasks 'mvn_install_tweenengine'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ ant.importBuild('java/build.xml') {
 }
 
 task mvn_install_tweenengine(dependsOn: package_tweenengine){
-	ext.mvn_dir = projectDir //Default setting assumes that maven is added to your path
+	ext.mvn_dir = project.hasProperty('mvn_dir') ? project.getProperty('mvn_dir') : projectDir //Default setting assumes that maven is added to your path
 	
 	doLast {
 		exec{

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ task mvn_install_tweenengine(dependsOn: package_tweenengine){
 			
 			def version = ant.properties['version']
 			
-			def cmdline = 'install:install-file -Dfile=' + projectDir + '/java/build/' + api_dir + '/' + api_name + '.jar -DgroupId=com.aurelienribon -DartifactId=tween-engine-api -Dversion=' + version + ' -Dpackaging=jar'
+			def cmdline = 'install:install-file -Dfile=' + projectDir + '/java/build/' + api_dir + '/' + api_name + '.jar -DgroupId=com.aurelienribon -DartifactId=' + api_name + ' -Dversion=' + version + ' -Dpackaging=jar'
 		
 			workingDir = mvn_dir
 			if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {


### PR DESCRIPTION
This gradle configuration is a wrapper for ants build.xml 
All tasks defined in build.xml will be exported as 'taskname_tweenengine' for gradle users

There is also a new task 'mvn_install_tweenengine' to install the built jar into the users local maven repository. Information like artifact name and version are taken from build.xml
This task assumes that maven is installed and added to the users path variable. If it is installed but NOT added to path one can specify the maven binary directory with mvn_install_tweenengine.mvn_dir